### PR TITLE
[CFE-484] Use right DT register value to save settings from operation…

### DIFF
--- a/kd6rmx.go
+++ b/kd6rmx.go
@@ -327,7 +327,7 @@ func (cis Sensor) SaveSettings(preset int) error {
 		return errors.New("invalid preset for SaveSettings")
 	}
 
-	param := fmt.Sprintf("%02X", preset)
+	param := fmt.Sprintf("%02X", 0x80+preset)
 	result, err := cis.sendCommand("DT", param)
 	if err != nil {
 		return err


### PR DESCRIPTION
Correct settings are mentioned on section 4.7 Direct memory control (page no 53) in Mitsubishi Contact Image Sensor（KD) Function Specification TM-XG553A