### PR TITLE
[CFE-479] Add function to dump register values of CIS

### DIFF
--- a/cmd/kd6ctl/main.go
+++ b/cmd/kd6ctl/main.go
@@ -284,11 +284,37 @@ func main() {
 		},
 	}
 
+	dumpreg := &ffcli.Command{
+		Name:       "dumpreg",
+		ShortUsage: "kd6ctl dumpreg",
+		ShortHelp:  "Dump the register values of CIS.",
+		Exec: func(_ context.Context, args []string) error {
+
+			cis := kd6rmx.Sensor{Port: *port}
+
+			cis.ReadRegister("BR")
+			cis.ReadRegister("OF")
+			cis.ReadRegister("OC")
+			cis.ReadRegister("RC")
+			cis.ReadRegister("SS")
+			cis.ReadRegister("DC")
+			cis.ReadRegister("LC")
+			cis.ReadRegisterWithVal("LC", "A0")
+			cis.ReadRegisterWithVal("LC", "C0")
+			cis.ReadRegister("WC")
+			cis.ReadRegister("PG")
+			cis.ReadRegister("GC")
+			cis.ReadRegister("TP")
+
+			return nil
+		},
+	}
+
 	root := &ffcli.Command{
 		ShortUsage:  "kd6ctl [flags] <subcommand>",
 		ShortHelp:   "kd6ctl is a command line utility to change config on the KD6RMX contact image sensor.",
 		FlagSet:     rootFlagSet,
-		Subcommands: []*ffcli.Command{version, load, save, outputfreq, outputfmt, interp, dark, white, leds, duty},
+		Subcommands: []*ffcli.Command{version, dumpreg, load, save, outputfreq, outputfmt, interp, dark, white, leds, duty},
 		Exec: func(context.Context, []string) error {
 			return flag.ErrHelp
 		},

--- a/kd6rmx.go
+++ b/kd6rmx.go
@@ -600,3 +600,33 @@ func checkError(funcname, result string) error {
 
 	return nil
 }
+
+func (cis Sensor) ReadRegister(register string) {
+	cis.ReadRegisterWithVal(register, "80")
+}
+
+func (cis Sensor) ReadRegisterWithVal(register, val string) {
+	result, err := cis.sendCommand(register, val)
+
+	fmt.Printf("Reading %s register with parameter 0x%s ", register, val)
+
+	if err == nil {
+		if result[:2] == "00" {
+			fmt.Printf("Reading SUCCESS. ")
+		} else {
+			fmt.Printf("Reading FAIL. ")
+		}
+
+		fmt.Print("Response from CIS ")
+
+		for index := 0; index < len(result); index += 2 {
+			fmt.Printf("0x%s ", result[index:index+2])
+		}
+
+		fmt.Println(" ")
+
+	} else {
+		fmt.Printf("Communication with CIS failed. Error reading register %s\n", register)
+	}
+
+}


### PR DESCRIPTION
Adding an option in cli to dump most of the registers of CIS. This is useful to debug the CIS calibration and configuration.