### PR TITLE
[CFE-478] Add Makefile to build, install, tag and release go-kd6rmx cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+# current git sha of the repo
+GITSHA := $(shell git rev-parse --short HEAD)
+
+# version
+VERSION := $(GITSHA)
+
+GOOS    := $(shell go env GOOS)
+GOARCH  := $(shell go env GOARCH)
+
+release: bump-version build-all tag
+
+tag:
+	git tag $(VERSION)
+	git push origin $(VERSION)
+
+build-windows: 
+	mkdir -p build/kd6ctl-$(VERSION)-windows-amd64
+	env GOOS=windows GOARCH=amd64 go build -o build/kd6ctl-$(VERSION)-windows-amd64/kd6ctl.exe ./cmd/kd6ctl
+
+build-linux:
+	mkdir -p build/kd6ctl-$(VERSION)-linux-amd64
+	env GOOS=linux GOARCH=amd64 go build -o build/kd6ctl-$(VERSION)-linux-amd64/kd6ctl ./cmd/kd6ctl
+
+build-macos:
+	mkdir -p build/kd6ctl-$(VERSION)-macos-amd64
+	env GOOS=darwin GOARCH=amd64 go build -o build/kd6ctl-$(VERSION)-macos-amd64/kd6ctl ./cmd/kd6ctl
+
+build-macos-m1:
+	mkdir -p build/kd6ctl-$(VERSION)-macos-arm64
+	env GOOS=darwin GOARCH=arm64 go build -o build/kd6ctl-$(VERSION)-macos-arm64/kd6ctl ./cmd/kd6ctl
+
+build-all: clean build-windows build-linux build-macos build-macos-m1
+
+.PHONY: build
+build:
+ifeq ($(GOOS), windows)
+	target_name="kd6ctl.exe"
+else
+	target_name="kd6ctl"
+endif
+	mkdir -p build/kd6ctl-$(VERSION)-$(GOOS)-$(GOARCH)
+	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o build/kd6ctl-$(VERSION)-$(GOOS)-$(GOARCH)/kd6ctl ./cmd/kd6ctl
+
+clean:
+	rm -rf build/*
+
+install:
+	go install ./cmd/kd6ctl 
+
+bump-version:
+	$(eval v := $(shell git describe --tags --abbrev=0 2>/dev/null | xargs git rev-parse | xargs git tag --points-at | tail -1 | sed -Ee 's/^v|-.*//'))
+ifeq ($(bump), major)
+	$(eval VERSION := v$(shell echo $v | awk -F'.' '{printf("%d.0.0", $$1+1, 0, 0)}'))
+else ifeq ($(bump), minor)
+	$(eval VERSION := v$(shell echo $v | awk -F'.' '{printf("%d.%d.0", $$1, $$2+1, 0)}'))
+else ifeq ($(bump), patch)
+	$(eval VERSION := v$(shell echo $v | awk -F'.' '{printf("%d.%d.%d", $$1, $$2, $$3+1)}'))
+else ifeq ($(bump), )
+	$(eval VERSION := v$(shell echo $v | awk -F'.' '{printf("%d.%d.%d", $$1, $$2, $$3+1)}'))
+else ifeq ($(bump), which)
+	$(eval VERSION := v$(shell echo $v | awk -F'.' '{printf("%d.%d.%d", $$1, $$2, $$3)}'))
+else
+	$(error $(bump) is not supported. available bump values are: major, minor, patch or leave empty for patch as default)
+endif
+	@echo bump version: $(VERSION)

--- a/README.md
+++ b/README.md
@@ -92,26 +92,63 @@ kd6ctl led ab on
 
 ### How to build binaries for different platforms
 
-#### Windows
+#### Windows (amd64 architecture)
 
 ```shell
-env GOOS=windows GOARCH=amd64 go build -o build/kd6ctl.exe ./cmd/kd6ctl
+make build-windows
 ```
 
-#### Linux
+#### Linux (amd64 architecture)
 
 ```shell
-env GOOS=linux GOARCH=amd64 go build -o build/kd6ctl ./cmd/kd6ctl
+make build-linux
 ```
 
-#### macOS - Intel
+#### macOS (amd64 architecture)
 
 ```shell
-env GOOS=darwin GOARCH=amd64 go build -o build/kd6ctl ./cmd/kd6ctl
+make build-macos
 ```
 
-#### macOS - M1
+#### macOS - M1 (arm64 architecture)
 
 ```shell
-env GOOS=darwin GOARCH=arm64 go build -o build/kd6ctl ./cmd/kd6ctl
+make build-macos-m1
+```
+
+#### All of above
+
+``` shell
+make build-all
+```
+
+#### build for the current platform (if you're unsure about the OS and architecture)
+
+```shell
+make build
+```
+
+#### Generic build command
+build binaries for other Operating Systems and architectures
+```shell
+env GOOS=<OS> GOARCH=<ARCH> go build -o build/kd6ctl-<OS>-<ARCH> ./cmd/kd6ctl
+```
+replace the ```OS``` by operating system and ```ARCH``` by architecture supported by go cross-compiler.
+
+### How to release a tagged version
+Following commands build binaries for Windows (amd64), Linux (amd64), macOS (amd64) and macOS M1 (arm64).
+
+Bump release tag to minor
+```shell
+make release bump=minor
+```
+
+Bump relase tag to major
+```shell
+make release bump=major
+```
+
+if bump argument is not mentiond, then the release will be bumped with tag patch
+```shell
+make release
 ```


### PR DESCRIPTION
Adding Makefile target to build, tag and release.

The binaries are generated into `./build` folder.

Example:

- `make build` to build binary for windows, macOS and linux
- `make release bump=minor` to tag, bump version and build binaries with tag.