### PR TITLE
Use target_name in Makefile to differentiate windows and rest of the builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ else
 	target_name="kd6ctl"
 endif
 	mkdir -p build/kd6ctl-$(VERSION)-$(GOOS)-$(GOARCH)
-	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o build/kd6ctl-$(VERSION)-$(GOOS)-$(GOARCH)/kd6ctl ./cmd/kd6ctl
+	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o build/kd6ctl-$(VERSION)-$(GOOS)-$(GOARCH)/$(target_name) ./cmd/kd6ctl
 
 clean:
 	rm -rf build/*


### PR DESCRIPTION
Small fix. Forgot to use variable `target_name` in Makefile.

`target_name` creates binary as either `kd6ctl.exe` (for windows) or `kd6ctl` for the rest of the builds.