### PR TITLE
Add verbosity flag

### DIFF
--- a/cmd/kd6ctl/main.go
+++ b/cmd/kd6ctl/main.go
@@ -17,6 +17,7 @@ func main() {
 	var (
 		rootFlagSet = flag.NewFlagSet("kd6ctl", flag.ExitOnError)
 		port        = rootFlagSet.String("p", "/dev/corser/XtiumCLMX41_s0", "port of KD6RMX sensor to use")
+		logging     = rootFlagSet.Bool("log", false, "turn on debug logging")
 	)
 
 	version := &ffcli.Command{
@@ -43,7 +44,7 @@ func main() {
 				return err
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 			return cis.LoadSettings(preset)
 		},
 	}
@@ -62,7 +63,7 @@ func main() {
 				return err
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 			return cis.SaveSettings(preset)
 		},
 	}
@@ -81,7 +82,7 @@ func main() {
 				return err
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 			return cis.OutputFrequency(float32(freq))
 		},
 	}
@@ -130,7 +131,7 @@ func main() {
 				return err
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 			return cis.PixelOutputFormat(bits, intf, conf, num)
 		},
 	}
@@ -154,7 +155,7 @@ func main() {
 				return fmt.Errorf("invalid interpolation, must be on or off")
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 			return cis.PixelInterpolation(on)
 		},
 	}
@@ -168,7 +169,7 @@ func main() {
 				return fmt.Errorf("dark correction requires a subcommand: 'on', 'off', or 'adjust'")
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 
 			switch args[0] {
 			case "on":
@@ -255,7 +256,7 @@ func main() {
 				}
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 			return cis.LEDControl(leds, on, pulse)
 		},
 	}
@@ -293,7 +294,7 @@ func main() {
 				return fmt.Errorf("adjust the gain number")
 			}
 
-			cis := kd6rmx.Sensor{Port: *port}
+			cis := kd6rmx.Sensor{Port: *port, Logging: *logging}
 			switch args[0] {
 			case "on":
 				cis.GainAmplifierEnabled(true)

--- a/kd6rmx.go
+++ b/kd6rmx.go
@@ -11,7 +11,8 @@ import (
 
 // Sensor is a wrapper for control functions for the KD6RMX contact image sensor.
 type Sensor struct {
-	Port string
+	Port    string
+	Logging bool
 }
 
 // CommunicationSpeed sets the communcation speed.
@@ -522,6 +523,7 @@ func (cis Sensor) TestPatternEnabled(on bool) error {
 	if err != nil {
 		return err
 	}
+
 	return checkError("TestPatternEnabled", result)
 }
 
@@ -570,7 +572,12 @@ func (cis Sensor) sendCommand(cmd string, params string) (string, error) {
 		return "", fmt.Errorf("error opening control port: %v", err)
 	}
 	defer f.Close()
-	_, err = f.Write([]byte(cmd + params + "\r"))
+	write_string := cmd + params + "\r"
+	if cis.Logging {
+		fmt.Println("send: ", write_string)
+	}
+
+	_, err = f.Write([]byte(write_string))
 	if err != nil {
 		return "", fmt.Errorf("error sending command: %v", err)
 	}
@@ -588,6 +595,9 @@ func (cis Sensor) sendCommand(cmd string, params string) (string, error) {
 		switch {
 		case result[len(result)-1] == '\r':
 			result = strings.Replace(result, "\r", "", -1)
+			if cis.Logging {
+				fmt.Println("received: ", result)
+			}
 			return result, nil
 		case n == 0:
 			return "", fmt.Errorf("no data in result from command")


### PR DESCRIPTION
Added feature to log send and received commands.
Use like this:
```
./kd6ctl -p /dev/corser/XtiumCLMX42_s0 -l=true frequency 84
send:  OF1C
received:  001C
```