### PR TITLE
add option to send commands straight to sensor

### DIFF
--- a/cmd/kd6ctl/main.go
+++ b/cmd/kd6ctl/main.go
@@ -337,11 +337,29 @@ func main() {
 		},
 	}
 
+	cmd := &ffcli.Command{
+		Name:       "cmd",
+		ShortUsage: "kd6ctl cmd <register> <value>",
+		ShortHelp:  "Sends the specified command to sensor",
+		Exec: func(_ context.Context, args []string) error {
+			if len(args) < 2 {
+				return fmt.Errorf("cmd command requires specific register and value you want to send")
+			}
+
+			register := args[0]
+			command := args[1]
+
+			cis := kd6rmx.Sensor{Port: *port}
+			cis.SendCommand(register, command)
+			return nil
+		},
+	}
+
 	root := &ffcli.Command{
 		ShortUsage:  "kd6ctl [flags] <subcommand>",
 		ShortHelp:   "kd6ctl is a command line utility to change config on the KD6RMX contact image sensor.",
 		FlagSet:     rootFlagSet,
-		Subcommands: []*ffcli.Command{version, dumpreg, gain, load, save, outputfreq, outputfmt, interp, dark, white, leds, duty},
+		Subcommands: []*ffcli.Command{version, dumpreg, gain, load, save, outputfreq, outputfmt, interp, dark, white, leds, duty, cmd},
 		Exec: func(context.Context, []string) error {
 			return flag.ErrHelp
 		},

--- a/kd6rmx.go
+++ b/kd6rmx.go
@@ -28,7 +28,7 @@ func (cis Sensor) CommunicationSpeed(baud int) error {
 		return errors.New("invalid baud rate")
 	}
 
-	_, err := cis.sendCommand("BR", param)
+	_, err := cis.SendCommand("BR", param)
 	return err
 }
 
@@ -98,7 +98,7 @@ func (cis Sensor) OutputFrequency(freq float32) error {
 		return errors.New("invalid output frequency")
 	}
 
-	result, err := cis.sendCommand("OF", val)
+	result, err := cis.SendCommand("OF", val)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (cis Sensor) PixelOutputFormat(bits PixelOutputBits, i PixelOutputInterface
 		return errors.New("invalid params for PixelOutputFormat")
 	}
 
-	result, err := cis.sendCommand("OC", param)
+	result, err := cis.SendCommand("OC", param)
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (cis Sensor) PixelOverlap(on bool) error {
 	if on {
 		param = "21"
 	}
-	result, err := cis.sendCommand("OC", param)
+	result, err := cis.SendCommand("OC", param)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func (cis Sensor) PixelInterpolation(on bool) error {
 		param = "41"
 	}
 
-	result, err := cis.sendCommand("OC", param)
+	result, err := cis.SendCommand("OC", param)
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func (cis Sensor) PixelResolution(res int) error {
 		return errors.New("invalid resolution")
 	}
 
-	result, err := cis.sendCommand("RC", param)
+	result, err := cis.SendCommand("RC", param)
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func (cis Sensor) PixelResolution(res int) error {
 
 // ExternalSync turns on the external sync.
 func (cis Sensor) ExternalSync() error {
-	result, err := cis.sendCommand("SS", "01")
+	result, err := cis.SendCommand("SS", "01")
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ func (cis Sensor) InternalSync(val int) error {
 	}
 
 	param := fmt.Sprintf("00%000X", val)
-	result, err := cis.sendCommand("SS", param)
+	result, err := cis.SendCommand("SS", param)
 	if err != nil {
 		return err
 	}
@@ -310,7 +310,7 @@ func (cis Sensor) LoadSettings(preset int) error {
 	}
 
 	param := fmt.Sprintf("%02X", preset)
-	result, err := cis.sendCommand("DT", param)
+	result, err := cis.SendCommand("DT", param)
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func (cis Sensor) SaveSettings(preset int) error {
 	}
 
 	param := fmt.Sprintf("%02X", 0x80+preset)
-	result, err := cis.sendCommand("DT", param)
+	result, err := cis.SendCommand("DT", param)
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,7 @@ func (cis Sensor) LEDControl(leds string, on bool, pulsedivider int) error {
 	}
 
 	param := fmt.Sprintf("%02X", val)
-	result, err := cis.sendCommand("LC", param)
+	result, err := cis.SendCommand("LC", param)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func (cis Sensor) LEDDutyCycle(led string, duty int) error {
 	}
 	param := fmt.Sprintf("%s%04X", ls, duty)
 
-	result, err := cis.sendCommand("LC", param)
+	result, err := cis.SendCommand("LC", param)
 	if err != nil {
 		return err
 	}
@@ -415,7 +415,7 @@ func (cis Sensor) DarkCorrectionEnabled(on bool) error {
 		param = "01"
 	}
 
-	result, err := cis.sendCommand("DC", param)
+	result, err := cis.SendCommand("DC", param)
 	if err != nil {
 		return err
 	}
@@ -423,7 +423,7 @@ func (cis Sensor) DarkCorrectionEnabled(on bool) error {
 }
 
 func (cis Sensor) PerformDarkCorrection() error {
-	result, err := cis.sendCommand("DC", "21")
+	result, err := cis.SendCommand("DC", "21")
 	if err != nil {
 		return err
 	}
@@ -436,7 +436,7 @@ func (cis Sensor) WhiteCorrectionEnabled(on bool) error {
 		param = "01"
 	}
 
-	result, err := cis.sendCommand("WC", param)
+	result, err := cis.SendCommand("WC", param)
 	if err != nil {
 		return err
 	}
@@ -444,7 +444,7 @@ func (cis Sensor) WhiteCorrectionEnabled(on bool) error {
 }
 
 func (cis Sensor) PerformWhiteCorrection() error {
-	result, err := cis.sendCommand("WC", "21")
+	result, err := cis.SendCommand("WC", "21")
 	if err != nil {
 		return err
 	}
@@ -458,7 +458,7 @@ func (cis Sensor) WhiteCorrectionTarget(target int) error {
 
 	h := fmt.Sprintf("%04X", target*16)
 
-	result, err := cis.sendCommand("WC40", h)
+	result, err := cis.SendCommand("WC40", h)
 	if err != nil {
 		return err
 	}
@@ -473,7 +473,7 @@ func (cis Sensor) GainAmplifierEnabled(on bool) error {
 		param = "01"
 	}
 
-	_, err := cis.sendCommand("PG", param)
+	_, err := cis.SendCommand("PG", param)
 	return err
 }
 
@@ -492,7 +492,7 @@ func (cis Sensor) GainAmplifierLevel(gain int) error {
 		param = fmt.Sprintf("21%04X", gain)
 	}
 
-	result, err := cis.sendCommand("PG", param)
+	result, err := cis.SendCommand("PG", param)
 	if err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func (cis Sensor) YCorrectionEnabled(on bool) error {
 		param = "01"
 	}
 
-	result, err := cis.sendCommand("OC", param)
+	result, err := cis.SendCommand("OC", param)
 	if err != nil {
 		return err
 	}
@@ -518,7 +518,7 @@ func (cis Sensor) TestPatternEnabled(on bool) error {
 		param = "01"
 	}
 
-	result, err := cis.sendCommand("TP", param)
+	result, err := cis.SendCommand("TP", param)
 	if err != nil {
 		return err
 	}
@@ -538,7 +538,7 @@ func (cis Sensor) TestPattern(pattern TestPatternType) error {
 		param = "21"
 	}
 
-	result, err := cis.sendCommand("TP", param)
+	result, err := cis.SendCommand("TP", param)
 	if err != nil {
 		return err
 	}
@@ -546,7 +546,7 @@ func (cis Sensor) TestPattern(pattern TestPatternType) error {
 }
 
 func (cis Sensor) SoftwareReset() error {
-	result, err := cis.sendCommand("SR", "21")
+	result, err := cis.SendCommand("SR", "21")
 	if err != nil {
 		return err
 	}
@@ -556,14 +556,14 @@ func (cis Sensor) SoftwareReset() error {
 
 	time.Sleep(10 * time.Second)
 
-	result, err = cis.sendCommand("SR", "01")
+	result, err = cis.SendCommand("SR", "01")
 	if err != nil {
 		return err
 	}
 	return checkError("SoftwareReset", result)
 }
 
-func (cis Sensor) sendCommand(cmd string, params string) (string, error) {
+func (cis Sensor) SendCommand(cmd string, params string) (string, error) {
 
 	f, err := os.OpenFile(cis.Port, os.O_RDWR|os.O_APPEND, 0777)
 	if err != nil {
@@ -899,7 +899,7 @@ func parseWhiteCorr(short_res string) error {
 }
 
 func (cis Sensor) ReadRegisterWithVal(register, val string) error {
-	result, err := cis.sendCommand(register, val)
+	result, err := cis.SendCommand(register, val)
 	if err != nil {
 		return errors.New("error: send command failed")
 	}


### PR DESCRIPTION
Allows you send send raw command 
e.g.
`./kd6ctl -p /dev/corser/XtiumCLMX42_s0 cmd DT 81`