### PR TITLE
parse sn

### DIFF
--- a/cmd/kd6ctl/main.go
+++ b/cmd/kd6ctl/main.go
@@ -362,6 +362,7 @@ func main() {
 			// cis.ReadRegister("GC")
 			cis.ReadRegister("TP")
 			cis.ReadRegisterWithVal("TP", "A0")
+			cis.ReadRegisterWithVal("SI", "C0")
 
 			return nil
 		},

--- a/kd6rmx.go
+++ b/kd6rmx.go
@@ -989,6 +989,18 @@ func parseTestPattern(short_res, val string) error {
 	return nil
 }
 
+func parseName(short_res, result, val string) error {
+	prod_num_p2 := result[4:6]
+	prod_num_p1 := result[6:8]
+	id := result[8:10]
+	m := result[10:12]
+	y := result[12:14]
+
+	sn := y + m + id + prod_num_p1 + prod_num_p2
+	fmt.Printf("(SN: %s)\n", sn)
+	return nil
+}
+
 func (cis Sensor) ReadRegisterWithVal(register, val string) error {
 	result, err := cis.SendCommand(register, val)
 	if err != nil {
@@ -1034,7 +1046,8 @@ func (cis Sensor) ReadRegisterWithVal(register, val string) error {
 		return parseWhiteCorr(short_res)
 	case "TP":
 		parseTestPattern(short_res, val)
-
+	case "SI":
+		return parseName(short_res, result, val)
 	default:
 		fmt.Printf("(default)")
 	}


### PR DESCRIPTION
add sn to dumpreg

./kd6ctl  dumpreg
Reading BR register with parameter 0x80 Response from CIS 0x00 0x00 (UART Setting: Baud rate: 9.6 MHz)
Reading OF register with parameter 0x80 Response from CIS 0x00 0x1C (Frequency: 84.0 MHz)
Reading OC register with parameter 0x80 Response from CIS 0x00 0x0B (Output Format: 8bit Serial Medium Configuration3)
Reading OC register with parameter 0xC0 Response from CIS 0x00 0x41 (Interpolation function On)
Reading RC register with parameter 0x80 Response from CIS 0x00 0x00 (Resolution: 600dpi)
Reading SS register with parameter 0x80 Response from CIS 0x00 0x01 (External synchronization)
Reading DC register with parameter 0x80 Response from CIS 0x00 0x01 (Black correction ON)
Reading LC register with parameter 0x80 Response from CIS 0x00 0x04 (Pulse2: OFF)
Reading LC register with parameter 0xA0 Response from CIS 0x00 0x20 0x01 0xF4 (LED Period A: 500)
Reading LC register with parameter 0xC0 Response from CIS 0x00 0x40 0x01 0xF4 (LED Period B: 500)
Reading WC register with parameter 0x80 Response from CIS 0x00 0x01 (White correction ON)
Reading TP register with parameter 0x80 Response from CIS 0x00 0x00 (Image output)
Reading SI register with parameter 0xC0 Response from CIS 0x00 0x40 0x13 0x00 0x09 0x02 0x21 (SN: 2102090013)